### PR TITLE
[MBAAS-5472] - Work through Fortify results for ArrowDbV2

### DIFF
--- a/session/session.go
+++ b/session/session.go
@@ -228,7 +228,7 @@ func (manager *Manager) SessionStart(w http.ResponseWriter, r *http.Request) (se
 	cookie := &http.Cookie{
 		Name:     manager.config.CookieName,
 		Value:    url.QueryEscape(sid),
-		Path:     "/",
+		Path:     "/v2",
 		HttpOnly: !manager.config.DisableHTTPOnly,
 		Secure:   manager.isSecure(r),
 		Domain:   manager.config.Domain,
@@ -267,7 +267,7 @@ func (manager *Manager) SessionDestroy(w http.ResponseWriter, r *http.Request) {
 	if manager.config.EnableSetCookie {
 		expiration := time.Now()
 		cookie = &http.Cookie{Name: manager.config.CookieName,
-			Path:     "/",
+			Path:     "/v2",
 			HttpOnly: !manager.config.DisableHTTPOnly,
 			Expires:  expiration,
 			MaxAge:   -1,


### PR DESCRIPTION
# Ticket
https://techweb.axway.com/jira/browse/MBAAS-5472

# Description
We recently dpdated Beego version, to develop-mbaas2 branch off appcelerator. This is to update appcelerator/BeeGo master/develop branch to latest release in order to fix fortify scan concerns.

Now for this PR we are addressing the two high level concerns mentioned in https://techweb.axway.com/confluence/display/~mzakariyya/Fortify+results+for+ArrowDbV2. The issues raised were in the nature of an overly broad path i.e more details in https://vulncat.fortify.com/en/detail?id=desc.semantic.java.cookie_security_overly_broad_path#Golang. 

1. Method: SessionStart()File: vendor/github.com/astaxie/beego/session/session.go:216. In the controller Prepare() method which is run before any other controller operations.. if the connect sid is not provided we have a regular app user so verify login session. this calls SessionStart() which again contains a overly broad path to create a cookie

2. Method: SessionDestroy()File: vendor/github.com/astaxie/beego/session/session.go:255. We are using this in user.go go destroy global sessions when logging out

For the fix we have added a trailing 'v2' into the cookie path

# Test
./run.sh